### PR TITLE
Adjust connection event handling

### DIFF
--- a/src/__tests__/request-test.js
+++ b/src/__tests__/request-test.js
@@ -87,6 +87,27 @@ describe("request", () => {
         message: "Not Found"
       });
     });
+
+    it("emits an error object on connection abort", () => {
+      const observer = {
+        error: jest.fn()
+      };
+
+      request("http://localhost").subscribe(observer);
+
+      const connectionMock = XHRConnection.mock.instances[0];
+      connectionMock.xhr = {
+        status: 0,
+        statusText: "abort"
+      };
+      const connectionEventMock = { target: connectionMock };
+      connectionMock.__emit(ConnectionEvent.ABORT, connectionEventMock);
+
+      expect(observer.error).toHaveBeenCalledWith({
+        code: 0,
+        message: "abort"
+      });
+    });
   });
 
   describe("with no subscribers", () => {

--- a/src/__tests__/stream-test.js
+++ b/src/__tests__/stream-test.js
@@ -90,6 +90,27 @@ describe("stream", () => {
         message: "Not Found"
       });
     });
+
+    it("emits an error object on connection abort", () => {
+      const observer = {
+        error: jest.fn()
+      };
+
+      stream("http://localhost").subscribe(observer);
+
+      const connectionMock = XHRConnection.mock.instances[0];
+      connectionMock.xhr = {
+        status: 0,
+        statusText: "abort"
+      };
+      const connectionEventMock = { target: connectionMock };
+      connectionMock.__emit(ConnectionEvent.ABORT, connectionEventMock);
+
+      expect(observer.error).toHaveBeenCalledWith({
+        code: 0,
+        message: "abort"
+      });
+    });
   });
 
   describe("with no subscribers", () => {

--- a/src/request.js
+++ b/src/request.js
@@ -13,7 +13,12 @@ export default function request(url, options = {}) {
         message: event.target.xhr.statusText
       });
     });
-
+    connection.addListener(ConnectionEvent.ABORT, function(event) {
+      observer.error({
+        code: event.target.xhr.status,
+        message: event.target.xhr.statusText
+      });
+    });
     connection.addListener(ConnectionEvent.COMPLETE, function(event) {
       observer.next(event.target.response);
       observer.complete();

--- a/src/stream.js
+++ b/src/stream.js
@@ -16,6 +16,12 @@ export default function stream(url, options = {}) {
         message: event.target.xhr.statusText
       });
     });
+    connection.addListener(ConnectionEvent.ABORT, function(event) {
+      observer.error({
+        code: event.target.xhr.status,
+        message: event.target.xhr.statusText
+      });
+    });
     connection.addListener(ConnectionEvent.COMPLETE, function() {
       observer.complete();
     });


### PR DESCRIPTION
Adjust the connection handling to emit an error on connection abort. This change was made as a connection abort form _outside_ should be considered an error as it doesn't align with the expressed intention and not handling the event at all results in stale Observables.

Closes DCOS-21783