### PR TITLE
Pass response with error object

### DIFF
--- a/src/__tests__/request-test.js
+++ b/src/__tests__/request-test.js
@@ -8,6 +8,18 @@ jest.mock("@dcos/connections", function() {
     ConnectionEvent: require.requireActual("@dcos/connections").ConnectionEvent,
     XHRConnection: jest.fn(function() {
       this.events = {};
+      Object.defineProperty(this, "response", {
+        get: function() {
+          return this.xhr.response;
+        },
+        set: function(value) {
+          if (!this.xhr) {
+            this.xhr = {};
+          }
+
+          this.xhr.response = value;
+        }
+      });
 
       this.addListener = (type, callback) => {
         if (!this.events[type]) {
@@ -77,14 +89,16 @@ describe("request", () => {
       const connectionMock = XHRConnection.mock.instances[0];
       connectionMock.xhr = {
         status: 404,
-        statusText: "Not Found"
+        statusText: "Not Found",
+        response: "not found"
       };
       const connectionEventMock = { target: connectionMock };
       connectionMock.__emit(ConnectionEvent.ERROR, connectionEventMock);
 
       expect(observer.error).toHaveBeenCalledWith({
         code: 404,
-        message: "Not Found"
+        message: "Not Found",
+        response: "not found"
       });
     });
 
@@ -98,14 +112,16 @@ describe("request", () => {
       const connectionMock = XHRConnection.mock.instances[0];
       connectionMock.xhr = {
         status: 0,
-        statusText: "abort"
+        statusText: "abort",
+        response: ""
       };
       const connectionEventMock = { target: connectionMock };
       connectionMock.__emit(ConnectionEvent.ABORT, connectionEventMock);
 
       expect(observer.error).toHaveBeenCalledWith({
         code: 0,
-        message: "abort"
+        message: "abort",
+        response: ""
       });
     });
   });

--- a/src/__tests__/stream-test.js
+++ b/src/__tests__/stream-test.js
@@ -9,6 +9,19 @@ jest.mock("@dcos/connections", function() {
     XHRConnection: jest.fn(function() {
       this.events = {};
 
+      Object.defineProperty(this, "response", {
+        get: function() {
+          return this.xhr.response;
+        },
+        set: function(value) {
+          if (!this.xhr) {
+            this.xhr = {};
+          }
+
+          this.xhr.response = value;
+        }
+      });
+
       this.addListener = (type, callback) => {
         if (!this.events[type]) {
           this.events[type] = [];
@@ -80,14 +93,16 @@ describe("stream", () => {
       const connectionMock = XHRConnection.mock.instances[0];
       connectionMock.xhr = {
         status: 404,
-        statusText: "Not Found"
+        statusText: "Not Found",
+        response: "not found"
       };
       const connectionEventMock = { target: connectionMock };
       connectionMock.__emit(ConnectionEvent.ERROR, connectionEventMock);
 
       expect(observer.error).toHaveBeenCalledWith({
         code: 404,
-        message: "Not Found"
+        message: "Not Found",
+        response: "not found"
       });
     });
 
@@ -101,14 +116,16 @@ describe("stream", () => {
       const connectionMock = XHRConnection.mock.instances[0];
       connectionMock.xhr = {
         status: 0,
-        statusText: "abort"
+        statusText: "abort",
+        response: ""
       };
       const connectionEventMock = { target: connectionMock };
       connectionMock.__emit(ConnectionEvent.ABORT, connectionEventMock);
 
       expect(observer.error).toHaveBeenCalledWith({
         code: 0,
-        message: "abort"
+        message: "abort",
+        response: ""
       });
     });
   });

--- a/src/request.js
+++ b/src/request.js
@@ -10,13 +10,15 @@ export default function request(url, options = {}) {
     connection.addListener(ConnectionEvent.ERROR, function(event) {
       observer.error({
         code: event.target.xhr.status,
-        message: event.target.xhr.statusText
+        message: event.target.xhr.statusText,
+        response: event.target.response
       });
     });
     connection.addListener(ConnectionEvent.ABORT, function(event) {
       observer.error({
         code: event.target.xhr.status,
-        message: event.target.xhr.statusText
+        message: event.target.xhr.statusText,
+        response: event.target.response
       });
     });
     connection.addListener(ConnectionEvent.COMPLETE, function(event) {

--- a/src/stream.js
+++ b/src/stream.js
@@ -13,13 +13,15 @@ export default function stream(url, options = {}) {
     connection.addListener(ConnectionEvent.ERROR, function(event) {
       observer.error({
         code: event.target.xhr.status,
-        message: event.target.xhr.statusText
+        message: event.target.xhr.statusText,
+        response: event.target.response
       });
     });
     connection.addListener(ConnectionEvent.ABORT, function(event) {
       observer.error({
         code: event.target.xhr.status,
-        message: event.target.xhr.statusText
+        message: event.target.xhr.statusText,
+        response: event.target.response
       });
     });
     connection.addListener(ConnectionEvent.COMPLETE, function() {


### PR DESCRIPTION
We're bumped into a case when a server sends a verbose error description along with 400 Response. This PR includes the response into the error object thus we can extract the information and show it to a user.

~Depends on #5~