### PR TITLE
DCOS-40469: add status code to next event

### DIFF
--- a/src/__tests__/request-test.js
+++ b/src/__tests__/request-test.js
@@ -71,12 +71,19 @@ describe("request", () => {
       request("http://localhost").subscribe(observer);
 
       const connectionMock = XHRConnection.mock.instances[0];
+      connectionMock.xhr = { status: 201, statusText: "CREATED" };
       connectionMock.response = "some text";
 
-      const connectionEventMock = { target: connectionMock };
+      const connectionEventMock = {
+        target: connectionMock
+      };
       connectionMock.__emit(ConnectionEvent.COMPLETE, connectionEventMock);
 
-      expect(observer.next).toHaveBeenCalledWith("some text");
+      expect(observer.next).toHaveBeenCalledWith({
+        response: "some text",
+        code: 201,
+        message: "CREATED"
+      });
     });
 
     it("emits an error object on connection error", () => {

--- a/src/request.js
+++ b/src/request.js
@@ -22,7 +22,11 @@ export default function request(url, options = {}) {
       });
     });
     connection.addListener(ConnectionEvent.COMPLETE, function(event) {
-      observer.next(event.target.response);
+      observer.next({
+        code: event.target.xhr.status,
+        message: event.target.xhr.statusText,
+        response: event.target.response
+      });
       observer.complete();
     });
 


### PR DESCRIPTION
BREAKING CHANGE: the output format of the next event changed. Instead of
`request(...).subscribe({next(response) {...}})` you can now write
`request(...).subscribe({next({ code, response }) {...}})`