### PR TITLE
[HOLD MERGE] DCOS-46037: update rxjs to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6064,11 +6064,11 @@
       "dev": true
     },
     "rxjs": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.3.tgz",
-      "integrity": "sha512-fSNi+y+P9ss+EZuV0GcIIqPUK07DEaMRUtLJvdcvMyFjc9dizuDjere+A4V7JrLGnm9iCc+nagV/4QdMTkqC4A==",
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
       "requires": {
-        "symbol-observable": "^1.0.1"
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -6880,11 +6880,6 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-    },
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
@@ -7306,6 +7301,11 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
   "dependencies": {
     "@dcos/connection-manager": "0.2.1",
     "@dcos/connections": "0.1.0",
-    "rxjs": "5.4.3"
+    "rxjs": "6.3.3"
   }
 }

--- a/src/request.js
+++ b/src/request.js
@@ -1,10 +1,9 @@
-import Rx from "rxjs";
-
+import { Observable } from "rxjs";
 import ConnectionManager from "@dcos/connection-manager";
 import { XHRConnection, ConnectionEvent } from "@dcos/connections";
 
 export default function request(url, options = {}) {
-  return Rx.Observable.create(function(observer) {
+  return Observable.create(function(observer) {
     const connection = new XHRConnection(url, options);
 
     connection.addListener(ConnectionEvent.ERROR, function(event) {

--- a/src/stream.js
+++ b/src/stream.js
@@ -1,10 +1,10 @@
-import Rx from "rxjs";
+import { Observable } from "rxjs";
 
 import ConnectionManager from "@dcos/connection-manager";
 import { XHRConnection, ConnectionEvent } from "@dcos/connections";
 
 export default function stream(url, options = {}) {
-  return Rx.Observable.create(function(observer) {
+  return Observable.create(function(observer) {
     const connection = new XHRConnection(url, options);
 
     connection.addListener(ConnectionEvent.DATA, function(event) {


### PR DESCRIPTION
Update rxjs to version 6.3.3.

Closes DCOS-46037.

## Important

This library is a dependency of `mesos-client` as well as `dcos-ui`. Hold merge until those repositories are also able to update to rxjs 6.x.

